### PR TITLE
Don't modify AWS prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,18 @@ S3...get it?  Writable stream interface for AWS S3.
 ### Piping a large file
 ```javascript
 var fs = require('fs');
-require('simple-storage-streams');
 var s3 = new require('aws-sdk').S3;
+var createS3WriteStream = require('s3-write-stream');
 
 var maxMemory = 0;
 setInterval(function(){
   maxMemory = Math.max(maxMemory, process.memoryUsage().heapUsed);
 }, 100);
 
-var writeable = s3.createWriteStream({Bucket: 'random-access-memories', Key: 'instant-crush.log'});
+var writeable = createS3WriteStream(s3, {
+  Bucket: 'random-access-memories',
+  Key: 'instant-crush.log'
+});
 
 // Imagine you have some massive file you want to upload that doesn't fit into memory
 fs.createReadStream('./big-file.log').pipe(writeable);
@@ -31,9 +34,9 @@ writeable.on('end', function(data) {
 ```javascript
 // It doesn't matter what order you load the modules in
 var s3 = new require('aws-sdk').S3;
-require('simple-storage-streams');
+var createS3WriteStream = require('simple-storage-streams');
 
-var writeable = s3.createWriteStream({
+var writeable = createWriteStream(s3, {
   Bucket: 'random-access-memories',
   Key: 'instant.crush'
 });

--- a/docs/index.html
+++ b/docs/index.html
@@ -69,37 +69,21 @@
               <div class="pilwrap for-h2">
                 <a class="pilcrow" href="#section-2">&#182;</a>
               </div>
-              <h2>AWS SDK</h2>
-<p>Load and export the AWS SDK. We will monkeypatch <code>AWS.S3&#39;s.prototype</code>.</p>
-<p>This module requires the AWS SDK module as a peer dependency, so it
-must be present in the parent package.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre><span class="keyword">var</span> AWS = require(<span class="string">'aws-sdk'</span>);
-module.exports = AWS;</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-3">
-            <div class="annotation">
-              
-              <div class="pilwrap for-h2">
-                <a class="pilcrow" href="#section-3">&#182;</a>
-              </div>
               <h2>CreateWriteStream</h2>
-<p>Define <code>AWS.S3.prototype.createWriteStream</code>.</p>
 <p>Usage:</p>
-<pre><code>require(&#39;s3-write-stream&#39;);
-var AWS = require(&#39;aws-sdk&#39;);
+<pre><code>var AWS = require(&#39;aws-sdk&#39;);
 var s3 = new AWS.S3(configParams);
+var createS3WriteStream = require(&#39;s3-write-stream&#39;);
 var targetFile = {Bucket: &#39;random-access-memories&#39;, Key: &#39;to-get-lucky.log&#39;};
-var s3stream = s3.createWriteStream(targetFile);;
+var s3stream = createS3WriteStream(s3, targetFile);;
 fs.createReadStream(&#39;./for-good-fun.log&#39;).pipe(s3stream);</code></pre>
-<p><code>createWriteStream()</code> accepts the same params object as
-<code>s3.createMultipartUpload()</code>.</p>
-<p>It will immediately return a writeable stream, but the stream will not
+<p>Arguments:</p>
+<ul>
+<li><code>s3</code>: Authenticated <code>AWS.S3</code> instance</li>
+<li><code>params</code>: same params object as <code>AWS.S3.createMultipartUpload()</code></li>
+<li><code>callback</code>: Optional, called with <code>(err, writeableStream)</code></li>
+</ul>
+<p>A writeable stream will be immediately returned, but the stream will not
 be ready yet. An upload ID must be retrieved from S3 before the stream
 will be ready. You can handle this in a few ways:</p>
 <ul>
@@ -112,19 +96,19 @@ Node&#39;s <code>stream.pipe()</code> behaves</li>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>AWS.S3.prototype.createWriteStream = <span class="keyword">function</span>(params, callback) {
-  <span class="keyword">var</span> s3stream = <span class="keyword">new</span> S3Stream(params, <span class="keyword">this</span>);
+            <div class="content"><div class='highlight'><pre>module.exports = <span class="keyword">function</span>(s3, params, callback) {
+  <span class="keyword">var</span> s3stream = <span class="keyword">new</span> S3Stream(params, s3);
 
-  <span class="keyword">this</span>.createMultipartUpload(params, <span class="keyword">function</span>(err, data) {</pre></div></div>
+  s3.createMultipartUpload(params, <span class="keyword">function</span>(err, data) {</pre></div></div>
             
         </li>
         
         
-        <li id="section-4">
+        <li id="section-3">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-4">&#182;</a>
+                <a class="pilcrow" href="#section-3">&#182;</a>
               </div>
               <p>Default callback to a noop</p>
 
@@ -135,11 +119,11 @@ Node&#39;s <code>stream.pipe()</code> behaves</li>
         </li>
         
         
-        <li id="section-5">
+        <li id="section-4">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-5">&#182;</a>
+                <a class="pilcrow" href="#section-4">&#182;</a>
               </div>
               <p>Pass errors to the callback and emit them from the stream</p>
 
@@ -153,11 +137,11 @@ Node&#39;s <code>stream.pipe()</code> behaves</li>
         </li>
         
         
-        <li id="section-6">
+        <li id="section-5">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-6">&#182;</a>
+                <a class="pilcrow" href="#section-5">&#182;</a>
               </div>
               <p>Set the <code>UploadId</code> from S3</p>
 
@@ -168,11 +152,11 @@ Node&#39;s <code>stream.pipe()</code> behaves</li>
         </li>
         
         
-        <li id="section-7">
+        <li id="section-6">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-7">&#182;</a>
+                <a class="pilcrow" href="#section-6">&#182;</a>
               </div>
               <p>Run the callback</p>
 
@@ -183,11 +167,11 @@ Node&#39;s <code>stream.pipe()</code> behaves</li>
         </li>
         
         
-        <li id="section-8">
+        <li id="section-7">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-8">&#182;</a>
+                <a class="pilcrow" href="#section-7">&#182;</a>
               </div>
               <p>Fire the &#39;writable&#39; event after the callback, in case the callback is
 mistakenly waiting for the event.</p>
@@ -200,11 +184,11 @@ mistakenly waiting for the event.</p>
         </li>
         
         
-        <li id="section-9">
+        <li id="section-8">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-9">&#182;</a>
+                <a class="pilcrow" href="#section-8">&#182;</a>
               </div>
               <p>Return the write stream</p>
 

--- a/index.js
+++ b/index.js
@@ -3,34 +3,26 @@
 // Loads the base S3Stream class, which extends `stream.Writable`.
 var S3Stream = require('./lib/Stream');
 
-// ## AWS SDK
-//
-// Load and export the AWS SDK. We will monkeypatch `AWS.S3's.prototype`.
-//
-// This module requires the AWS SDK module as a peer dependency, so it
-// must be present in the parent package.
-var AWS = require('aws-sdk');
-module.exports = AWS;
-
 // ## CreateWriteStream
 //
-// Define `AWS.S3.prototype.createWriteStream`.
-// 
 // Usage:
 //
 // ```
-// require('s3-write-stream');
 // var AWS = require('aws-sdk');
 // var s3 = new AWS.S3(configParams);
+// var createS3WriteStream = require('s3-write-stream');
 // var targetFile = {Bucket: 'random-access-memories', Key: 'to-get-lucky.log'};
-// var s3stream = s3.createWriteStream(targetFile);;
+// var s3stream = createS3WriteStream(s3, targetFile);;
 // fs.createReadStream('./for-good-fun.log').pipe(s3stream);
 // ```
 //
-// `createWriteStream()` accepts the same params object as
-// `s3.createMultipartUpload()`.
+// Arguments:
 // 
-// It will immediately return a writeable stream, but the stream will not
+// * `s3`: Authenticated `AWS.S3` instance
+// * `params`: same params object as `AWS.S3.createMultipartUpload()`
+// * `callback`: Optional, called with `(err, writeableStream)`
+// 
+// A writeable stream will be immediately returned, but the stream will not
 // be ready yet. An upload ID must be retrieved from S3 before the stream
 // will be ready. You can handle this in a few ways:
 // 
@@ -39,10 +31,10 @@ module.exports = AWS;
 //   when the stream is ready
 // * Start writing immediately and respect `false` return values. This is how
 //   Node's `stream.pipe()` behaves
-AWS.S3.prototype.createWriteStream = function(params, callback) {
-  var s3stream = new S3Stream(params, this);
+module.exports = function(s3, params, callback) {
+  var s3stream = new S3Stream(params, s3);
 
-  this.createMultipartUpload(params, function(err, data) {
+  s3.createMultipartUpload(params, function(err, data) {
     // Default callback to a noop
     callback = callback || function(){};
 

--- a/index.js
+++ b/index.js
@@ -17,15 +17,15 @@ var S3Stream = require('./lib/Stream');
 // ```
 //
 // Arguments:
-// 
+//
 // * `s3`: Authenticated `AWS.S3` instance
 // * `params`: same params object as `AWS.S3.createMultipartUpload()`
 // * `callback`: Optional, called with `(err, writeableStream)`
-// 
+//
 // A writeable stream will be immediately returned, but the stream will not
 // be ready yet. An upload ID must be retrieved from S3 before the stream
 // will be ready. You can handle this in a few ways:
-// 
+//
 // * Wait for the stream to emit a `writable` event
 // * Provide a callback, which will be called with `(err, writeableStream)`
 //   when the stream is ready

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "devDependencies": {
     "should": "~1.2.2",
     "mocha": "~1.12.0",
-    "proxyquire": "~0.4.1",
     "grunt": "~0.4.1",
     "grunt-gh-pages": "~0.6.0",
     "grunt-docco-multi": "0.0.2",

--- a/test/S3Queue.js
+++ b/test/S3Queue.js
@@ -63,4 +63,3 @@ describe('S3Queue', function() {
     q.push(bigChunk);
   });
 });
- 

--- a/test/awsShim.js
+++ b/test/awsShim.js
@@ -181,7 +181,7 @@ describe('AWS Shim, testing the tests', function() {
             err.should.be.instanceof(Error);
             err.message.should.equal(key + ' is required');
             cb();
-          });        
+          });
         }, done);
       });
     });

--- a/test/createWriteStream.js
+++ b/test/createWriteStream.js
@@ -2,15 +2,14 @@ var fs = require('fs');
 var crypto = require('crypto');
 var should = require('should');
 
-// Overload the AWS library with the shim
-var proxyquire =  require('proxyquire');
+// Replace the AWS library with the shim
 var awsShim = require('./shim/aws');
-proxyquire.noCallThru().load('../index', { 'aws-sdk': awsShim });
+var createWriteStream = require('../index');
 
 var getStream = function(cb) {
   var s3Shim = new awsShim.S3();
   var params = {Bucket: 'test-bucket', Key: 'testkey.log'};
-  return s3Shim.createWriteStream(params, cb);
+  return createWriteStream(s3Shim, params, cb);
 };
 
 


### PR DESCRIPTION
Hello @dpup, @thebyrd, @kylehardgrave, 

This updates the interface for creating a writable stream based on [this comment thread](https://github.com/Obvious/simple-storage-streams/commit/a579521df1467be3711a9d6a502f5d36f7a1a1ba#commitcomment-3823509).

Please review the following commits I made in branch 'es-dont-change-aws'.

e1a73f49a23b2ad7b04939be28beb3cb427e1cfd (2013-08-09 17:43:32 -0400)
Update docs

1205a8698c6cb9dcbc22ece20eb68cd97939e935 (2013-08-09 17:43:12 -0400)
Kill some trailing whitespace

69d60c2cacacebef3309d105d717b19151275149 (2013-08-09 17:41:24 -0400)
Use new s3 instance param in tests
Remove proxyquire dependency, we no longer need to overload aws-sdk, we just load the shim directly

d11e6dbc7db92192d42c19787b2827ff519da3f2 (2013-08-09 17:39:48 -0400)
Stop modifying the AWS prototype
Instead accept an s3 instance as an argument

R=@dpup
R=@thebyrd
R=@kylehardgrave
