### PR TITLE
Publish JSDoc documentation on GitHub pages

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,7 +1,12 @@
 module.exports = function(grunt) {
+  var path = require('path');
+  var docsRoot = '.grunt/docs';
+
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-exec');
   grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-jsdoc');
+  grunt.loadNpmTasks('grunt-gh-pages');
 
   grunt.initConfig({
     watch: {
@@ -14,9 +19,31 @@ module.exports = function(grunt) {
         tasks: 'exec:test'
       }
     },
+    jsdoc: {
+      docs: {
+        src: ['./*.js', './lib/*.js'],
+        options: {
+          destination: docsRoot,
+          private: true
+        }
+      }
+    },
+    'gh-pages': {
+      docs: {
+        src: '**/*',
+        options: {
+          base: docsRoot
+        }
+      }
+    },
     exec: {
       test: {
         command: 'npm test'
+      },
+      docsIndex: {
+        // The default index page is mostly empty and confusing
+        // This sets it to use the main class' docs
+        command: 'cp ' + [path.join(docsRoot, 'S3Utils.html'), path.join(docsRoot, 'index.html')].join(' ')
       }
     },
     jshint: {
@@ -24,5 +51,6 @@ module.exports = function(grunt) {
     },
   });
 
-  grunt.registerTask('default', ['jshint', 'exec:test']);
+  grunt.registerTask('default', ['jshint', 'exec:test', 'docs']);
+  grunt.registerTask('docs', ['jsdoc:docs', 'exec:docsIndex']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -53,4 +53,5 @@ module.exports = function(grunt) {
 
   grunt.registerTask('default', ['jshint', 'exec:test', 'docs']);
   grunt.registerTask('docs', ['jsdoc:docs', 'exec:docsIndex']);
+  grunt.registerTask('prepublish', ['default', 'gh-pages']);
 };

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "s3-utils",
   "version": "0.1.0",
-  "engines" : {
-    "node" : ">=0.10.0"
+  "engines": {
+    "node": ">=0.10.0"
   },
   "engineStrict": true,
   "description": "Write objects to S3 as a Node.js 0.10-friendly stream",
@@ -47,6 +47,8 @@
     "grunt-contrib-jshint": "~0.6.2",
     "async": "~0.2.9",
     "grunt-exec": "~0.4.2",
-    "grunt-contrib-watch": "~0.5.1"
+    "grunt-contrib-watch": "~0.5.1",
+    "grunt-jsdoc": "~0.4.0",
+    "grunt-gh-pages": "~0.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "homepage": "https://github.com/Obvious/simple-storage-streams",
   "main": "index.js",
   "scripts": {
-    "test": "mocha test/*.js --reporter spec --check-leaks"
+    "test": "mocha test/*.js --reporter spec --check-leaks",
+    "prepublish": "grunt prepublish"
   },
   "author": {
     "name": "Evan Solomon",


### PR DESCRIPTION
Hello @dpup, 

Please review the following commits I made in branch 'es-docs-gh-pages'.

This replaces the old Docco docs site.

1b1a2a0db9a7ffe2211bd61d2d4ce4f4eefec4ab (2013-09-03 17:37:07 -0700)
Add npm prepublish task to update docs on GH pages

8f6551dd7c6f393693cf2b27c2d8fef4cf00ad28 (2013-09-03 11:52:51 -0700)
Publish jsdoc on github pages

R=@dpup
