### PR TITLE
Use proper capitalization in require()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Canoe
 
+[![Build Status](https://secure.travis-ci.org/Obvious/canoe.png)](http://travis-ci.org/Obvious/canoe)
+
 Paddle downstream with Canoe, an S3 utility library for Node.js. Built on the [AWS Node SDK](https://github.com/aws/aws-sdk-js).
 
 ## Install

--- a/test/S3Queue.js
+++ b/test/S3Queue.js
@@ -2,7 +2,7 @@
 
 var events = require('events');
 var crypto = require('crypto');
-var S3Queue = require('../lib/queue');
+var S3Queue = require('../lib/Queue');
 var should = require('should');
 
 // Compute this here so Mocha doesn't get annoyed by a slow test


### PR DESCRIPTION
Hello @evansolomon, 

Please review the following commits I made in branch 'es-fix-ci-fails'.

28504977733b076bec4d27cf0f0564377a2cdb5f (2013-09-04 17:45:29 -0700)
Use proper capitalization in require()
Apparently OSX's filesystem is lenient about this

R=@evansolomon
