### PR TITLE
Speedup by calling Buffer.concat less often.

### DIFF
--- a/lib/Queue.js
+++ b/lib/Queue.js
@@ -20,11 +20,12 @@ util.inherits(S3Queue, EventEmitter);
 module.exports = S3Queue;
 
 /**
- * Reset the queue's internal buffer. Emits a 'reset' event.
+ * Reset the queue's internal chunk storage. Emits a 'reset' event.
  */
 S3Queue.prototype.reset = function () {
   this.emit('reset');
-  this.buffer = new Buffer(0);
+  this.chunks = [];
+  this.size = 0;
 };
 
 /**
@@ -44,7 +45,7 @@ S3Queue.prototype.threshold = function () {
  * @return {Boolean} True if the queue is full.
  */
 S3Queue.prototype.full = function () {
-  return this.buffer.length >= this.threshold();
+  return this.size >= this.threshold();
 };
 
 /**
@@ -55,7 +56,8 @@ S3Queue.prototype.full = function () {
  * @param {Buffer} chunk Data to add to the queue.
  */
 S3Queue.prototype.push = function (chunk) {
-  this.buffer = Buffer.concat([this.buffer, chunk]);
+  this.chunks.push(chunk);
+  this.size += chunk.length;
   if (this.full()) this.drain();
 
   this.emit('push', chunk);
@@ -66,7 +68,7 @@ S3Queue.prototype.push = function (chunk) {
  * with the data as a Buffer.
  */
 S3Queue.prototype.drain = function () {
-  var body = this.buffer;
+  var body = Buffer.concat(this.chunks, this.size);
   this.reset();
 
   this.emit('drain', body);

--- a/test/S3Queue.js
+++ b/test/S3Queue.js
@@ -22,7 +22,7 @@ describe('S3Queue', function() {
 
   it('Should set initial state', function() {
     var q = new S3Queue();
-    q.buffer.toString().should.equal('');
+    q.chunks.toString().should.equal('');
   });
 
   it('Should add chunk', function(done) {
@@ -44,7 +44,7 @@ describe('S3Queue', function() {
     var nextChunk = new Buffer("and it isn't stopping");
     q.push(nextChunk);
 
-    q.buffer.toString().should.equal("I know your life is speeding and it isn't stopping");
+    q.chunks.join('').should.equal("I know your life is speeding and it isn't stopping");
   });
 
   it('Should drain when full', function(done) {


### PR DESCRIPTION
Hello @evansolomon, 

Please review the following commits I made in branch 'tyler-less-concat-calls'.

23afd5aacac4431e9f43a68ae9187914799f4e9b (2013-09-06 04:36:59 +0000)
Speedup by calling Buffer.concat less often.

R=@evansolomon
