### PR TITLE
Add grunt publish task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,6 +8,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-jsdoc');
   grunt.loadNpmTasks('grunt-gh-pages');
   grunt.loadNpmTasks('grunt-benchmark');
+  grunt.loadNpmTasks('grunt-release');
 
   grunt.initConfig({
     watch: {
@@ -54,10 +55,14 @@ module.exports = function(grunt) {
     },
     jshint: {
       files: ['index.js', 'lib/*.js']
-    },
+    }
   });
 
   grunt.registerTask('default', ['jshint', 'exec:test', 'docs']);
   grunt.registerTask('docs', ['jsdoc:docs', 'exec:docsIndex']);
-  grunt.registerTask('prepublish', ['default', 'gh-pages']);
+
+  grunt.registerTask('publish', 'Publish a new version, defaults to patch', function (type) {
+    if (! type) type = 'patch';
+    grunt.task.run('default', 'release:' + type, 'gh-pages');
+  });
 };

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "grunt-contrib-watch": "~0.5.1",
     "grunt-jsdoc": "~0.4.0",
     "grunt-gh-pages": "~0.7.1",
-    "grunt-benchmark": "~0.2.0"
+    "grunt-benchmark": "~0.2.0",
+    "grunt-release": "~0.5.1"
   }
 }


### PR DESCRIPTION
The goal is to make releasing a new version a one-command process.  e.g. `grunt publish` or `grunt publish:major`
- Runs linter
- Runs tests
- Updates docs
- Updates package version
- Creates Git tag
- Pushes repo + tags
- Publishes new tagged version to NPM
- Updates GitHub documentation site
