### PR TITLE
Add benchmarks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,6 +7,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-jsdoc');
   grunt.loadNpmTasks('grunt-gh-pages');
+  grunt.loadNpmTasks('grunt-benchmark');
 
   grunt.initConfig({
     watch: {
@@ -17,6 +18,11 @@ module.exports = function(grunt) {
       tests: {
         files: ['test/**/*'],
         tasks: 'exec:test'
+      }
+    },
+    benchmark: {
+      all: {
+        src: 'benchmark/**/*.js'
       }
     },
     jsdoc: {

--- a/benchmark/queue/create.js
+++ b/benchmark/queue/create.js
@@ -1,0 +1,8 @@
+var S3Queue = require('../../lib/Queue');
+
+module.exports = {
+  name: 'S3Queue: Create instance',
+  fn: function() {
+    var q = new S3Queue();
+  }
+};

--- a/benchmark/queue/push-many-items.js
+++ b/benchmark/queue/push-many-items.js
@@ -1,0 +1,36 @@
+var crypto = require('crypto');
+var S3Queue = require('../../lib/Queue');
+var q = new S3Queue();
+
+// Create a bunch of dummy data to add to our queue
+// Use different chunk sizes but make each set add up to the same total size
+var testSizes = ['Big', 'Medium', 'Small'];
+
+var randomBytes = {};
+testSizes.forEach(function(size) {
+  randomBytes[size] = [];
+});
+var largeChunkSize = 100000;
+
+var i, j, factor;
+for (i = 0; i < 100; i++) {
+  factor = 1;
+  testSizes.forEach(function (size) {
+    for (j = 0; j < factor; j++) randomBytes[size].push(crypto.randomBytes(largeChunkSize / factor));
+    factor *= 10;
+  });
+}
+
+var tests = {};
+testSizes.forEach(function (testSize) {
+  var testName = testSize + ' items';
+  tests[testName] = function() {
+    randomBytes[testSize].forEach(q.push.bind(q));
+    q.reset();
+  };
+});
+
+module.exports = {
+  name: 'S3Queue: Push many items (~10 MB)',
+  tests: tests
+};

--- a/benchmark/queue/push-one-item.js
+++ b/benchmark/queue/push-one-item.js
@@ -1,0 +1,18 @@
+var crypto = require('crypto');
+var S3Queue = require('../../lib/Queue');
+var q = new S3Queue();
+
+var randomItem = crypto.randomBytes(10000);
+var largeRandomItem = crypto.randomBytes(10000000);
+
+module.exports = {
+  name: 'S3Queue: Push one item',
+  tests: {
+    'Push one small item': function() {
+      q.push(randomItem);
+    },
+    'Push one large item': function() {
+      q.push(largeRandomItem);
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "grunt-exec": "~0.4.2",
     "grunt-contrib-watch": "~0.5.1",
     "grunt-jsdoc": "~0.4.0",
-    "grunt-gh-pages": "~0.7.1"
+    "grunt-gh-pages": "~0.7.1",
+    "grunt-benchmark": "~0.2.0"
   }
 }


### PR DESCRIPTION
Start with S3Queue, and add a Grunt task to run them (`grunt benchmark`).

Todo: add benchmarks for other classes/methods and add future benchmarks for performance improvements (e.g. #7).
