### PR TITLE
Standardize "finish" event behavior

### DIFF
--- a/lib/Stream.js
+++ b/lib/Stream.js
@@ -71,8 +71,8 @@ S3Stream.prototype.setupEvents = function () {
   // emit drain/flush events
   this.on('uploaded', this.trackUploadedPart.bind(this))
   this.on('uploaded', function () {
-    // 'drain' is emitted when the stream is writable or ending
-    if (_this.ready() || _this.almostEnding) _this.emit('drain')
+    // 'drain' is emitted when the stream is writable
+    if (_this.ready()) _this.emit('drain')
 
     // 'flush' is emitted when the stream has no active uploads
     if (_this.activeUploads === 0) _this.emit('flush')
@@ -95,14 +95,14 @@ S3Stream.prototype._write = function (chunk, encoding, callback) {
   // queue's next `drain` event. If the stream has been ended, call its
   // complete() method and run the callback on its `complete` event.
   this.queue.once('push', function () {
-    if (_this.ready()) return callback()
-
-    var doneEvent = _this.almostEnding ? 'complete' : 'drain'
-    _this.once(doneEvent, function () {
+    if (_this.almostEnding) {
+      _this.once('complete', callback)
+      _this.complete()
+    } else if (_this.ready()) {
       callback()
-    })
-
-    if (_this.almostEnding) _this.complete()
+    } else {
+      _this.once('drain', callback)
+    }
   })
 
   // If the queue is initialized, push this chunk
@@ -160,9 +160,6 @@ S3Stream.prototype.end = function (chunk, encoding, callback) {
  * @return {Boolean} True if the stream is ready.
  */
 S3Stream.prototype.ready = function () {
-  // If the stream is ending, we can't be ready for more data
-  if (this.almostEnding) return false
-
   return !! (this.initialized() && this.activeUploads < this.maxActiveUploads)
 }
 

--- a/lib/Stream.js
+++ b/lib/Stream.js
@@ -123,7 +123,9 @@ S3Stream.prototype._write = function (chunk, encoding, callback) {
  * was called. We use this to know when to complete the upload and avoid
  * calling _write()'s callback too early.
  *
- * @param  {(String|Buffer)=} chunk The data to write to the stream.
+ * @param {(String|Buffer)=} chunk The data to write to the stream.
+ * @param {String=} encoding The encoding, if chunk is a String.
+ * @param {Function=} callback Optional callback for when the stream is finished.
  */
 S3Stream.prototype.end = function (chunk, encoding, callback) {
   this.almostEnding = true

--- a/lib/Stream.js
+++ b/lib/Stream.js
@@ -36,6 +36,7 @@ S3Stream.prototype.init = function () {
   this.uploadedParts = []
   this.activeUploads = 0
   this.maxActiveUploads = 1
+  this.almostEnding = false
 
   // Setup a queue instance
   this.setupQueue()
@@ -62,9 +63,6 @@ S3Stream.prototype.setupQueue = function () {
 S3Stream.prototype.setupEvents = function () {
   var _this = this
 
-  // Complete the upload when the stream's 'finish' event fires
-  this.once('finish', this.complete.bind(this))
-
   // By default, abort the upload on any error. Unbind this event with:
   // `s3stream.removeListener('error', s3stream.abort)`
   this.on('error', this.abort.bind(this))
@@ -73,8 +71,8 @@ S3Stream.prototype.setupEvents = function () {
   // emit drain/flush events
   this.on('uploaded', this.trackUploadedPart.bind(this))
   this.on('uploaded', function () {
-    // 'drain' is emitted when the stream is writable
-    if (_this.ready()) _this.emit('drain')
+    // 'drain' is emitted when the stream is writable or ending
+    if (_this.ready() || _this.almostEnding) _this.emit('drain')
 
     // 'flush' is emitted when the stream has no active uploads
     if (_this.activeUploads === 0) _this.emit('flush')
@@ -94,9 +92,17 @@ S3Stream.prototype._write = function (chunk, encoding, callback) {
 
   // On the queue's `push` event, fire the callback if the queue is ready
   // for more data. If the queue is not ready, fire the callback on the
-  // queue's next `drain` event
+  // queue's next `drain` event. If the stream has been ended, call its
+  // complete() method and run the callback on its `complete` event.
   this.queue.once('push', function () {
-    return _this.ready() ? callback() : _this.once('drain', callback)
+    if (_this.ready()) return callback()
+
+    var doneEvent = _this.almostEnding ? 'complete' : 'drain'
+    _this.once(doneEvent, function () {
+      callback()
+    })
+
+    if (_this.almostEnding) _this.complete()
   })
 
   // If the queue is initialized, push this chunk
@@ -113,11 +119,48 @@ S3Stream.prototype._write = function (chunk, encoding, callback) {
 }
 
 /**
+ * Subclass stream.Writable.end so that we can set a flag to indicate end()
+ * was called. We use this to know when to complete the upload and avoid
+ * calling _write()'s callback too early.
+ *
+ * @param  {(String|Buffer)=} chunk The data to write to the stream.
+ */
+S3Stream.prototype.end = function (chunk, encoding, callback) {
+  this.almostEnding = true
+
+  // Borrow some code from Node's _stream_writable.js
+  // https://github.com/joyent/node/blob/v0.10.0-release/lib/_stream_writable.js#L312-L319
+  //
+  // We might need to manipulate chunk. This helps handle cases
+  // where arguments aren't what we think they are.
+  if (typeof chunk === 'function') {
+    callback = chunk
+    chunk = null
+    encoding = null
+  } else if (typeof encoding === 'function') {
+    callback = encoding
+    encoding = null
+  }
+
+  // Make sure chunk is not null-like. This forces the parent's end() to
+  // call write(), which is where we handle completing the upload.
+  if (chunk == null) chunk = ''
+
+  // If no chunk argument is passed at all, create the arg when we call the parent
+  var args = arguments.length ? arguments : [chunk]
+
+  S3Stream.super_.prototype.end.apply(this, args)
+}
+
+/**
  * Check whether the stream is ready to accept data.
  *
  * @return {Boolean} True if the stream is ready.
  */
 S3Stream.prototype.ready = function () {
+  // If the stream is ending, we can't be ready for more data
+  if (this.almostEnding) return false
+
   return !! (this.initialized() && this.activeUploads < this.maxActiveUploads)
 }
 
@@ -209,7 +252,7 @@ S3Stream.prototype.trackUploadedPart = function (err, data) {
 /**
  * Finishes a multi-part upload. Any remaning data is flushed from the
  * underlying queue. Once all parts have been uploaded to S3 and the
- * 'flush' event is fired, completion starts. The stream emits an 'end'
+ * 'flush' event is fired, completion starts. The stream emits a 'complete'
  * event when the completed upload finishes with `err` and `response`
  * arguments.
  */
@@ -229,7 +272,7 @@ S3Stream.prototype.complete = function () {
 
     _this.s3.completeMultipartUpload(params, function (err, response) {
       if (err) _this.emit('error', err)
-      _this.emit('end', err, response)
+      _this.emit('complete', err, response)
     })
   })
 }

--- a/lib/Stream.js
+++ b/lib/Stream.js
@@ -151,7 +151,7 @@ S3Stream.prototype.end = function (chunk, encoding, callback) {
   // If no chunk argument is passed at all, create the arg when we call the parent
   var args = arguments.length ? arguments : [chunk]
 
-  S3Stream.super_.prototype.end.apply(this, args)
+  return S3Stream.super_.prototype.end.apply(this, args)
 }
 
 /**

--- a/test/createWriteStream.js
+++ b/test/createWriteStream.js
@@ -58,6 +58,17 @@ describe('S3 createWriteStream', function() {
     })
   })
 
+  it('Should error on writes after end', function(done) {
+    getStream(function(err, stream) {
+      stream.end("'Cause it doesn't happen every day")
+
+      stream.write('Rewind', function(err) {
+        err.should.be.instanceof(Error)
+        done()
+      })
+    })
+  })
+
   it('Should write data', function(done) {
     getStream(function(err, stream) {
       var lyric = "Kinda counted on you being a friend"

--- a/test/createWriteStream.js
+++ b/test/createWriteStream.js
@@ -132,6 +132,15 @@ describe('S3 createWriteStream', function() {
     getStream().write(bigContent).should.not.be.ok
   })
 
+  it('Should complete upload even if chunk argument to end() is false', function(done) {
+    var stream = getStream()
+    stream.on('complete', done)
+
+    stream.write("Driving this road down to paradise\n")
+    stream.write("Letting the sunlight into my eyes")
+    stream.end(false)
+  })
+
   it('Should finish the chorus', function() {
     var stream = getStream()
     stream.end("So I chained myself to a friend\n'Cause I know it unlocks like a door")

--- a/test/createWriteStream.js
+++ b/test/createWriteStream.js
@@ -58,6 +58,16 @@ describe('S3 createWriteStream', function() {
     })
   })
 
+  it('Should emit "complete" before "finish"', function (done) {
+    getStream(function(err, stream) {
+      stream.once('complete', function () {
+        stream.once('finish', done)
+      })
+
+      stream.end("Shadows on you break out into the light")
+    })
+  })
+
   it('Should error on writes after end', function(done) {
     getStream(function(err, stream) {
       stream.end("'Cause it doesn't happen every day")

--- a/test/createWriteStream.js
+++ b/test/createWriteStream.js
@@ -58,16 +58,6 @@ describe('S3 createWriteStream', function() {
     })
   })
 
-  it('Should emit "end" event after finish event', function(done) {
-    getStream(function(err, stream) {
-      stream.on('finish', function() {
-        stream.on('end', done)
-      })
-
-      stream.end("Kinda given up on giving away")
-    })
-  })
-
   it('Should write data', function(done) {
     getStream(function(err, stream) {
       var lyric = "Kinda counted on you being a friend"
@@ -77,7 +67,7 @@ describe('S3 createWriteStream', function() {
         body += chunk.toString()
       })
 
-      stream.on('end', function() {
+      stream.on('finish', function() {
         body.should.equal(lyric)
         done()
       })
@@ -93,7 +83,7 @@ describe('S3 createWriteStream', function() {
         body += chunk.toString()
       })
 
-      stream.on('end', function(err) {
+      stream.on('finish', function(err) {
         var expected = fs.readFileSync(__filename, 'utf8')
         body.should.equal(expected, 'Did not write file contents correctly')
 
@@ -106,7 +96,7 @@ describe('S3 createWriteStream', function() {
   it('Should handle immediate writes', function(done) {
     var stream = getStream()
 
-    stream.on('end', done)
+    stream.on('finish', done)
     stream.end("Now I thought about what I wanna say")
   })
 


### PR DESCRIPTION
Hello @tylerneylon, 

Please review the following commits I made in branch 'es-finish-event'.

e46e5658d44fa2c006105d194f0e08565643b2d8 (2013-09-13 15:03:49 -0700)
Return parent's end() value
This doesn't do anything useful now, but it seems like a reasonably safe future idea

5153e747818a4651d0bf459772c2d61f4ef447e6 (2013-09-13 15:03:49 -0700)
Add missing param docs

560ef541d2ed1cda7683a8ed65cddc84009a9df4 (2013-09-09 20:20:05 -0700)
Add test case for 'complete' firing before 'finish'

90a27cabf4952a0b375120e84072bab05e9c4996 (2013-09-09 20:20:05 -0700)
Add test case for writes failing after end() is called

37e1544cbb16abf5b5559574d989565b114b256d (2013-09-09 20:20:05 -0700)
Update unit tests for new 'finish' event behavior

b8c12348c19f3a621ab7e2129181a3b74a25a999 (2013-09-09 20:20:05 -0700)
Standardize stream's 'finish' event
Subclass stream.Writable.end so that we can observe when the stream is ending and delay the finish event until the upload is complete

R=@tylerneylon
