### PR TITLE
Use finish event to trigger the end of an upload.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ var canoe = new Canoe(s3);
 
 ## Methods
 
-### createWriteStream
+### createWriteStream(params, [callback], [threshold])
 
 A Node 0.10-friendly writable stream interface ("streams2") for uploading objects to S3.
 
@@ -30,7 +30,14 @@ A Node 0.10-friendly writable stream interface ("streams2") for uploading object
 
 Creates a writable stream for a given S3 bucket/key. The stream will be returned immediately and also passed to an optional callback.
 
-The stream will be writable when it's returned, but not actually ready to send data to S3 yet (data will be buffered internally in the meantime). If you use the immediately returned stream, be sure to respect `false`-y return values, as Node's `readable.pipe()` does. The stream will be fully ready when the callback is run.
+The `params` object is expected to have keys `Bucket` and `Key` to specify the S3 destination. Examples are below.
+
+The optional `callback` function is called once the S3 upload process has been initialized.
+The stream will be immediately writable when it's returned, although data may be buffered until the S3 upload process is initialized.
+If you use the immediately returned stream, be sure to respect `false`-y return values, as Node's `readable.pipe()` does. Data uploads can begin when the callback is run.
+
+The optional `threshold` parameter allows you to set values higher than 5MB for the minimum multipart upload size.  5MB is the default and minimum value accepted by AWS.
+Since there is a 10,000-part maximum, higher thresholds are useful for files that exceed 50,000MB (which is close to, but technically different from, 50GB).
 
 The stream will emit a `writable` event when it's ready to send data to S3.
 

--- a/index.js
+++ b/index.js
@@ -32,10 +32,12 @@ module.exports = Canoe
  *
  * @param {Object} params Params to create an instance of S3Stream
  * @param {Function=} callback Called when the stream is ready.
+ * @param {number=} threshold Minimum part size to upload; default and smallest valid value is 5MB.
  * @return {Stream} Writable stream
  */
-Canoe.prototype.createWriteStream = function (params, callback) {
+Canoe.prototype.createWriteStream = function (params, callback, threshold) {
   var s3stream = new S3Stream(params, this.s3)
+  if (threshold) s3stream.setThreshold(threshold)
 
   this.s3.createMultipartUpload(params, function (err, data) {
     // Default callback to a noop

--- a/lib/Queue.js
+++ b/lib/Queue.js
@@ -13,7 +13,8 @@ var EventEmitter = require('events').EventEmitter
 function S3Queue(threshold) {
   EventEmitter.call(this)
 
-  this._threshold = threshold
+  this.threshold = threshold
+  this.drainable = false
   this.reset()
 }
 util.inherits(S3Queue, EventEmitter)
@@ -26,50 +27,60 @@ S3Queue.prototype.reset = function () {
   this.emit('reset')
   this.chunks = []
   this.size = 0
+  this.callbacks = []
 }
 
 /**
- * Get the queue's threshold and enforce a minimum of 5 mb. AWS' minimum
- * size for S3 partial uploads is 5mb, except for the last part, which can
- * be whatever size is remaining.
+ * Set whether or not the queue drains when it's full.
+ * A drain event may be triggered immediately if the queue is full when
+ * drainable is set to true.
  *
- * @return {Number} Threshold in bytes.
+ * @param {Boolean} drainable Whether or not the queue should drain when it's full.
  */
-S3Queue.prototype.threshold = function () {
-  return Math.max(this._threshold || 0, 5 * 1024 * 1024)
+S3Queue.prototype.setDrainable = function (drainable) {
+  this.drainable = drainable
+  this.drainIfNeeded()
 }
 
 /**
- * Determine whether the queue is full, based on its threshold.
+ * Returns true if and only if the queue has at least as much data
+ * as the threshold level.
  *
- * @return {Boolean} True if the queue is full.
+ * @return {Boolean}
  */
 S3Queue.prototype.full = function () {
-  return this.size >= this.threshold()
+  return this.size >= this.threshold
 }
 
 /**
- * Add a chunk to the queue to be uploaded. Triggers Queue.drain()
- * when the queue is full after the chunk is added. Emits a 'push'
- * event.
+ * Add a chunk and callback to the queue to be uploaded. Triggers a drain event
+ * when the queue is full after the chunk is added. The callback is called immediately
+ * except when both the queue is full and not drainable, as this is the case when
+ * continued writes are known to continuously fill memory.
  *
  * @param {Buffer} chunk Data to add to the queue.
+ * @param {Function} callback Function to be called now or later, depending on if new data will eat extra memory.
  */
-S3Queue.prototype.push = function (chunk) {
+S3Queue.prototype.push = function (chunk, callback) {
   this.chunks.push(chunk)
   this.size += chunk.length
-  if (this.full()) this.drain()
-
-  this.emit('push', chunk)
+  if (this.drainable || !this.full()) {
+    setImmediate(callback)
+  } else {
+    this.callbacks.push(callback)
+  }
+  this.drainIfNeeded()
 }
 
 /**
- * Drain the data currently in the queue. Emits a 'drain' event
- * with the data as a Buffer.
+ * Emit a drain event if the queue is full and drainable.
  */
-S3Queue.prototype.drain = function () {
-  var body = Buffer.concat(this.chunks, this.size)
-  this.reset()
+S3Queue.prototype.drainIfNeeded = function () {
+  if (!this.drainable || !this.full()) return
 
-  this.emit('drain', body)
+  var body = Buffer.concat(this.chunks, this.size)
+  var callbacks = this.callbacks
+  this.reset()
+  this.emit('drain', body, callbacks)
 }
+

--- a/lib/Stream.js
+++ b/lib/Stream.js
@@ -4,6 +4,8 @@ var util = require('util')
 var Writable = require('stream').Writable
 var S3Queue = require('./Queue')
 
+var MIN_UPLOAD = 5 * 1024 * 1024
+
 /**
  * Writable stream interface for S3. Inherits stream.Writable
  *
@@ -20,6 +22,7 @@ function S3Stream(params, s3) {
   // Cache inputs
   this.params = params
   this.s3 = s3
+  this.uploadFn = this.upload.bind(this)
 
   // Set the stream's initial state, create a queue, and bind event listeners
   this.init()
@@ -36,8 +39,7 @@ S3Stream.prototype.init = function () {
   this.uploadedParts = []
   this.activeUploads = 0
   this.maxActiveUploads = 1
-  this.endHasBeenCalled = false
-  this.completeHasBeenCalled = false
+  this.finishHasBeenCalled = false
 
   // Setup a queue instance
   this.setupQueue()
@@ -51,17 +53,18 @@ S3Stream.prototype.init = function () {
  * method to the queue's 'drain' event.
  */
 S3Stream.prototype.setupQueue = function () {
-  this.queue = new S3Queue()
-  this.queue.on('drain', this.upload.bind(this))
+  this.queue = new S3Queue(MIN_UPLOAD)
+  this.queue.on('drain', this.uploadFn)
 }
 
 /**
  * Set the minimum size (in bytes) to upload in a non-final part.
+ * The theshold is set to 5mb if the given amount is smaller.
  *
  * @param {Number} bytes Minimum upload size.
  */
 S3Stream.prototype.setThreshold = function (bytes) {
-  this.queue._threshold = bytes
+  this.queue.threshold = Math.max(bytes, MIN_UPLOAD)
   return this
 }
 
@@ -78,15 +81,11 @@ S3Stream.prototype.setupEvents = function () {
   // `s3stream.removeListener('error', s3stream.abort)`
   this.on('error', this.abort.bind(this))
 
-  // When uploads complete, track the uploaded part and
-  // emit drain/flush events
-  this.on('uploaded', function () {
-    // 'drain' is emitted when the stream is writable
-    if (_this.ready()) _this.emit('drain')
+  // The queue will not emit any drain events before our writable event.
+  this.on('writable', function () { _this.queue.setDrainable(true) })
 
-    // 'flush' is emitted when the stream has no active uploads
-    if (_this.activeUploads === 0) _this.emit('flush')
-  })
+  // This event is emitted by the node api; it means we've received all data.
+  this.on('finish', this.finish.bind(this))
 }
 
 /**
@@ -98,89 +97,7 @@ S3Stream.prototype.setupEvents = function () {
  * @param {Function} callback Called when the chunk is successfully handled.
  */
 S3Stream.prototype._write = function (chunk, encoding, callback) {
-  var _this = this
-
-  // On the queue's `push` event, fire the callback if the queue is ready
-  // for more data. If the queue is not ready, fire the callback on the
-  // queue's next `drain` event. If the stream has been ended, call its
-  // complete() method and run the callback on its `complete` event.
-  this.queue.once('push', function () {
-    if (_this.endHasBeenCalled) {
-      _this.once('complete', callback)
-      _this.complete()
-    } else if (_this.ready()) {
-      callback()
-    } else {
-      _this.once('drain', callback)
-    }
-  })
-
-  // If the queue is initialized, push this chunk
-  if (this.initialized()) {
-    this.queue.push(chunk)
-
-  // If the queue is not initialized yet, push this chunk when it fires
-  // its `writable` event
-  } else {
-    this.once('writable', function () {
-      _this.queue.push(chunk)
-    })
-  }
-}
-
-/**
- * Subclass stream.Writable.end so that we can set a flag to indicate end()
- * was called. We use this to know when to complete the upload and avoid
- * calling _write()'s callback too early.
- *
- * @param {(String|Buffer)=} chunk The data to write to the stream.
- * @param {String=} encoding The encoding, if chunk is a String.
- * @param {Function=} callback Optional callback for when the stream is finished.
- */
-S3Stream.prototype.end = function (chunk, encoding, callback) {
-  this.endHasBeenCalled = true
-
-  // Borrow some code from Node's _stream_writable.js
-  // https://github.com/joyent/node/blob/v0.10.0-release/lib/_stream_writable.js#L312-L319
-  //
-  // We might need to manipulate chunk. This helps handle cases
-  // where arguments aren't what we think they are.
-  if (typeof chunk === 'function') {
-    callback = chunk
-    chunk = null
-    encoding = null
-  } else if (typeof encoding === 'function') {
-    callback = encoding
-    encoding = null
-  }
-
-  // If chunk is truthy, _write will be called, so we'll have a chance
-  // to finish the upload from there, knowing it's the end thanks to
-  // this.endHasBeenCalled.
-  if (chunk) return S3Stream.super_.prototype.end.apply(this, arguments)
-
-  // If chunk is falsy, _write won't be called again, so we initiate
-  // completion now, and will call parent's end() when that completes.
-  this.complete()
-  this._endArguments = arguments
-}
-
-/**
- * Check whether the stream is ready to accept data.
- *
- * @return {Boolean} True if the stream is ready.
- */
-S3Stream.prototype.ready = function () {
-  return !! (this.initialized() && this.activeUploads < this.maxActiveUploads)
-}
-
-/**
- * Check whether the stream has been initialized with an S3 upload ID.
- *
- * @return {Boolean} True if the stream has an upload ID.
- */
-S3Stream.prototype.initialized = function () {
-  return !! this.params.UploadId
+  this.queue.push(chunk, callback)
 }
 
 /**
@@ -219,8 +136,9 @@ S3Stream.prototype.getUploadParams = function (extraParams) {
  * Upload a chunk of data to S3. Emits an 'uploaded' event on completion.
  *
  * @param {Buffer} body Chunk of data to upload.
+ * @param {Array.<Function>} callbacks Callbacks to be called when the upload completes.
  */
-S3Stream.prototype.upload = function (body) {
+S3Stream.prototype.upload = function (body, callbacks) {
   var _this = this
   this.uploadPartNumber++
   var partNumber = this.uploadPartNumber
@@ -231,8 +149,12 @@ S3Stream.prototype.upload = function (body) {
   })
 
   this.activeUploads++
+  if (this.activeUploads === this.maxActiveUploads) this.queue.setDrainable(false)
   this.s3.uploadPart(params, function (err, response) {
     _this.activeUploads--
+    if (_this.params.UploadId && !_this.queue.drainable) {
+      _this.queue.setDrainable(true)
+    }
 
     if (err) {
       _this.emit('error', err)
@@ -244,46 +166,49 @@ S3Stream.prototype.upload = function (body) {
         PartNumber: partNumber
       })
     }
+    callbacks.forEach(function (callback) { callback() })
+    if (_this.finishHasBeenCalled) {
+      if (_this.activeUploads === 0) _this.complete()
+    } else {
+      _this.queue.drainIfNeeded()
+    }
     _this.emit('uploaded', err, response, body)
-
   })
 }
 
 /**
- * Finishes a multi-part upload. Any remaning data is flushed from the
- * underlying queue. Once all parts have been uploaded to S3 and the
- * 'flush' event is fired, completion starts. The stream emits a 'complete'
- * event when the completed upload finishes with `err` and `response`
- * arguments.
+ * Start the final, and possibly very-small (including 0 bytes), upload;
+ * setting finishHasBeenCalled will trigger complete() when all uploads reach 0.
+ */
+S3Stream.prototype.finish = function () {
+  this.finishHasBeenCalled = true
+
+  // Accept one more drain of any size. This handles two cases:
+  // (1) The writable event has occurred, and we drain & upload now; or
+  // (2) writable has not occurred, but we'll upload as soon as it occurs.
+  this.queue.threshold = 0
+  this.queue.removeListener('drain', this.uploadFn)
+  this.queue.once('drain', this.uploadFn)  // Avoid more than 1 last upload.
+  this.queue.drainIfNeeded()
+}
+
+/**
+ * Completes a multi-part upload. When the completion is done, the stream
+ * emits a 'close' event with `err` and `response` arguments.
  */
 S3Stream.prototype.complete = function () {
   var _this = this
 
-  // Ensure this is called at most once, and only runs after the
-  // writable event has occured so the queue has a chance to accept data.
-  if (!this.initialized()) return this.once('writable', this.complete)
-  if (this.completeHasBeenCalled) return
-  this.completeHasBeenCalled = true
+  this.uploadedParts.sort(function (a, b) {
+    return a.PartNumber < b.PartNumber ? -1 : 1
+  })
 
-  this.queue.drain()
-  this.once('flush', function () {
-    // Parts have to be sorted in ascending order
-    _this.uploadedParts.sort(function (a, b) {
-      return a.PartNumber < b.PartNumber ? -1 : 1
-    })
+  var params = this.getUploadParams({
+    MultipartUpload: {Parts: this.uploadedParts}
+  })
 
-    var params = _this.getUploadParams({
-      MultipartUpload: {Parts: _this.uploadedParts}
-    })
-
-    _this.s3.completeMultipartUpload(params, function (err, response) {
-      if (err) _this.emit('error', err)
-      _this.emit('complete', err, response)
-      // If end() was called without a chunk, then we must call our
-      // parent's end() now to let it know the write has finished.
-      if (_this._endArguments) {
-        S3Stream.super_.prototype.end.apply(_this, _this._endArguments)
-      }
-    })
+  this.s3.completeMultipartUpload(params, function (err, response) {
+    if (err) _this.emit('error', err)
+    _this.emit('close', err, response)
   })
 }

--- a/test/S3Queue.js
+++ b/test/S3Queue.js
@@ -6,8 +6,9 @@ var S3Queue = require('../lib/Queue')
 var should = require('should')
 
 // Compute this here so Mocha doesn't get annoyed by a slow test
-var q = new S3Queue()
-var bigChunk = crypto.randomBytes(q.threshold())
+var THRESHOLD = 1024
+var q = new S3Queue(THRESHOLD)
+var bigChunk = crypto.randomBytes(q.threshold)
 
 describe('S3Queue', function () {
   it('Should exist', function () {
@@ -25,15 +26,11 @@ describe('S3Queue', function () {
     q.chunks.toString().should.equal('')
   })
 
-  it('Should add chunk', function (done) {
-    var q = new S3Queue()
+  it('Should add chunk', function () {
+    var q = new S3Queue(THRESHOLD)
     var chunk = new Buffer("I know you don't get chance to take a break this often")
-    q.on('push', function (pushed) {
-      var err = chunk === pushed ? null : 'Incorrect chunk added'
-      done(err)
-    })
-
     q.push(chunk)
+    q.chunks.should.not.be.empty
   })
 
   it('Should add multiple chunks', function () {
@@ -48,7 +45,8 @@ describe('S3Queue', function () {
   })
 
   it('Should drain when full', function (done) {
-    var q = new S3Queue()
+    var q = new S3Queue(THRESHOLD)
+    q.setDrainable(true)
     // Make a temp listener to check that drain doesn't fire before it should
     var dontDrainYet = function () {
       done('Drained too early')
@@ -58,7 +56,7 @@ describe('S3Queue', function () {
     q.removeListener('drain', dontDrainYet)
 
     q.on('drain', function (body) {
-      body.length.should.be.above(q.threshold(), 'Drained body length')
+      body.length.should.be.above(q.threshold, 'Drained body length')
       done()
     })
 


### PR DESCRIPTION
Hello @evansolomon, 

Please review the following commits I made in branch 'tyler-use-finish-event'.

f172ebcfff48fbd8ab68ef6794fa5205a124959a (2013-11-20 00:12:40 +0000)
Use finish event to trigger the end of an upload.
This drops use of the end() function to determine the end of incoming
data, replacing it with the node-api-generated finish event.

It also holds some write callbacks when further write calls will
definitely use more than the stream's threshold of memory. This allows
us to not manually emit the drain event, as the node api will do that
for us.

The complete event has been dropped in favor of the close event, which
is not documented officially but is recommended by isaacs and is used in
other places in the node api. We now let the node api trigger finish
first, to indicate that we've received all data; and we later trigger
the close event to indicate that all data has been received by S3,
including the upload completion call.Check list:

R=@evansolomon
