### PR TITLE
Use "close" event to indicate fully uploaded data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.3.0
+* `S3Stream` -- Fix a race condition that caused the upload to be completed to early when `end()` happened to get called while there were no active uploads.
+* `S3Stream` -- Introduce new `close` event, which fires *after* `finish` and means that the data is completely uploaded to S3.
+
 ### 0.2.2
 #### September 30, 2013
 * `S3Stream` -- Fix a bug that caused data to never upload when objects were an exact multiple of the threshold (e.g. 10mb).

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Creates a writable stream for a given S3 bucket/key. The stream will be returned
 
 The stream will be writable when it's returned, but not actually ready to send data to S3 yet (data will be buffered internally in the meantime). If you use the immediately returned stream, be sure to respect `false`-y return values, as Node's `readable.pipe()` does. The stream will be fully ready when the callback is run.
 
-The stream will emit a `writable` event when it's ready to send data to S3.
+The stream will emit a `writable` event when it's ready to send data to S3. A `close` event will be emitted when the stream is fully done consuming (uploading) the data; this will happen *after* the `finish` event.
 
 Basic usage:
 
@@ -63,7 +63,7 @@ setInterval(function() {
   maxMemory = Math.max(maxMemory, process.memoryUsage().heapUsed);
 }, 100);
 
-writeable.on('finish', function(data) {
+writeable.on('close', function(data) {
   console.log('Peak memory heap usage was ' + maxMemory + ' bytes');
   process.exit();
 });

--- a/lib/Stream.js
+++ b/lib/Stream.js
@@ -36,8 +36,6 @@ S3Stream.prototype.init = function () {
   this.uploadedParts = []
   this.activeUploads = 0
   this.maxActiveUploads = 1
-  this.endHasBeenCalled = false
-  this.completeHasBeenCalled = false
 
   // Setup a queue instance
   this.setupQueue()
@@ -87,6 +85,9 @@ S3Stream.prototype.setupEvents = function () {
     // 'flush' is emitted when the stream has no active uploads
     if (_this.activeUploads === 0) _this.emit('flush')
   })
+
+  // Complete the upload when the stream's 'finish' event fires
+  this.once('finish', this.complete.bind(this));
 }
 
 /**
@@ -105,10 +106,7 @@ S3Stream.prototype._write = function (chunk, encoding, callback) {
   // queue's next `drain` event. If the stream has been ended, call its
   // complete() method and run the callback on its `complete` event.
   this.queue.once('push', function () {
-    if (_this.endHasBeenCalled) {
-      _this.once('complete', callback)
-      _this.complete()
-    } else if (_this.ready()) {
+    if (_this.ready()) {
       callback()
     } else {
       _this.once('drain', callback)
@@ -126,43 +124,6 @@ S3Stream.prototype._write = function (chunk, encoding, callback) {
       _this.queue.push(chunk)
     })
   }
-}
-
-/**
- * Subclass stream.Writable.end so that we can set a flag to indicate end()
- * was called. We use this to know when to complete the upload and avoid
- * calling _write()'s callback too early.
- *
- * @param {(String|Buffer)=} chunk The data to write to the stream.
- * @param {String=} encoding The encoding, if chunk is a String.
- * @param {Function=} callback Optional callback for when the stream is finished.
- */
-S3Stream.prototype.end = function (chunk, encoding, callback) {
-  this.endHasBeenCalled = true
-
-  // Borrow some code from Node's _stream_writable.js
-  // https://github.com/joyent/node/blob/v0.10.0-release/lib/_stream_writable.js#L312-L319
-  //
-  // We might need to manipulate chunk. This helps handle cases
-  // where arguments aren't what we think they are.
-  if (typeof chunk === 'function') {
-    callback = chunk
-    chunk = null
-    encoding = null
-  } else if (typeof encoding === 'function') {
-    callback = encoding
-    encoding = null
-  }
-
-  // If chunk is truthy, _write will be called, so we'll have a chance
-  // to finish the upload from there, knowing it's the end thanks to
-  // this.endHasBeenCalled.
-  if (chunk) return S3Stream.super_.prototype.end.apply(this, arguments)
-
-  // If chunk is falsy, _write won't be called again, so we initiate
-  // completion now, and will call parent's end() when that completes.
-  this.complete()
-  this._endArguments = arguments
 }
 
 /**
@@ -262,8 +223,6 @@ S3Stream.prototype.complete = function () {
   // Ensure this is called at most once, and only runs after the
   // writable event has occured so the queue has a chance to accept data.
   if (!this.initialized()) return this.once('writable', this.complete)
-  if (this.completeHasBeenCalled) return
-  this.completeHasBeenCalled = true
 
   this.queue.drain()
   this.once('flush', function () {
@@ -278,12 +237,7 @@ S3Stream.prototype.complete = function () {
 
     _this.s3.completeMultipartUpload(params, function (err, response) {
       if (err) _this.emit('error', err)
-      _this.emit('complete', err, response)
-      // If end() was called without a chunk, then we must call our
-      // parent's end() now to let it know the write has finished.
-      if (_this._endArguments) {
-        S3Stream.super_.prototype.end.apply(_this, _this._endArguments)
-      }
+      _this.emit('close', err, response)
     })
   })
 }

--- a/test/createWriteStream.js
+++ b/test/createWriteStream.js
@@ -90,7 +90,7 @@ describe('S3 createWriteStream', function () {
   it('Should complete even when the data size = threshold', function (done) {
     getStream(function (err, stream) {
       stream.setThreshold(5 * 1024 * 1024)
-        .on('complete', done)
+        .on('close', done)
         .write(getLargeString(5))  // Send in 5MB.
       stream.end()
     })
@@ -98,7 +98,7 @@ describe('S3 createWriteStream', function () {
 
   it('Should complete even when the data size = 0', function (done) {
     getStream(function (err, stream) {
-      stream.on('complete', done)
+      stream.on('close', done)
       stream.end()
     })
   })
@@ -110,10 +110,10 @@ describe('S3 createWriteStream', function () {
     })
   })
 
-  it('Should emit "complete" before "finish"', function (done) {
+  it('Should emit "close" after "finish"', function (done) {
     getStream(function (err, stream) {
-      stream.once('complete', function () {
-        stream.once('finish', done)
+      stream.once('finish', function () {
+        stream.once('close', done)
       })
 
       stream.end("Shadows on you break out into the light")
@@ -140,7 +140,7 @@ describe('S3 createWriteStream', function () {
         body += chunk.toString()
       })
 
-      stream.on('finish', function () {
+      stream.on('close', function () {
         body.should.equal(lyric)
         done()
       })
@@ -156,7 +156,7 @@ describe('S3 createWriteStream', function () {
         body += chunk.toString()
       })
 
-      stream.on('finish', function (err) {
+      stream.on('close', function (err) {
         var expected = fs.readFileSync(__filename, 'utf8')
         body.should.equal(expected, 'Did not write file contents correctly')
 
@@ -169,7 +169,7 @@ describe('S3 createWriteStream', function () {
   it('Should handle immediate writes', function (done) {
     var stream = getStream()
 
-    stream.on('finish', done)
+    stream.on('close', done)
     stream.end("Now I thought about what I wanna say")
   })
 
@@ -186,7 +186,7 @@ describe('S3 createWriteStream', function () {
 
   it('Should complete upload even if chunk argument to end() is false', function (done) {
     var stream = getStream()
-    stream.on('complete', done)
+    stream.on('close', done)
 
     stream.write("Driving this road down to paradise\n")
     stream.write("Letting the sunlight into my eyes")


### PR DESCRIPTION
Hello @tylerneylon, 

Please review the following commits I made in branch 'es-close-event'.

0957f29734a24fd8e005181f89c1aafdb28206b8 (2013-11-18 16:46:07 -0800)
Add changelog for close event + race condition fix

ed96b463c5e0f4a6a5c075039594bab6e3cd8108 (2013-11-18 16:31:21 -0800)
Update tests and readme with "close" event

2d147a8aa8ec28413167c6bada0e0b3b9bef758c (2013-11-18 16:29:10 -0800)
Use "close" event to indicate finished comsumption
Fixes a race condition with active uploads and end being called. Also remvoes the complexity of having to subclass end().

Relevant:
- https://github.com/joyent/node/issues/5315
- https://github.com/joyent/node/issues/5336
- https://groups.google.com/forum/#!searchin/nodejs/_write/nodejs/ydWIyPrDVB4/Rt4EZk0YNgcJ

R=@tylerneylon
