### PR TITLE
Support AWS SDK's default params

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,11 +30,18 @@ module.exports = Canoe
  *   })
  *   fs.createReadStream('./for-good-fun.log').pipe(s3stream)
  *
- * @param {Object} params Params to create an instance of S3Stream
+ * @param {Object=} params Params to create an instance of S3Stream. Matches params
+ *   from AWS.S3.createMultipartUpload().
  * @param {Function=} callback Called when the stream is ready.
  * @return {Stream} Writable stream
  */
 Canoe.prototype.createWriteStream = function (params, callback) {
+  // Handle createWriteStream(fn)
+  if (typeof params === 'function') {
+    callback = params
+    params = null
+  }
+
   var s3stream = new S3Stream(params, this.s3)
 
   this.s3.createMultipartUpload(params, function (err, data) {

--- a/index.js
+++ b/index.js
@@ -41,10 +41,18 @@ Canoe.prototype.createWriteStream = function (params, callback) {
     // Default callback to a noop
     callback = callback || function () {}
 
+    // Pass an error to the callback and emit it from the stream
+    function throwError(err) {
+      s3stream.emit('error', err)
+      callback(err)
+    }
+
     // Pass errors to the callback and emit them from the stream
     if (err) {
-      s3stream.emit('error', err)
-      return callback(err)
+      return throwError(err)
+    }
+    if (! data || ! data.UploadId) {
+      return throwError(new Error('Could not generate an UploadId'))
     }
 
     // Set the `UploadId` from S3

--- a/lib/Stream.js
+++ b/lib/Stream.js
@@ -18,7 +18,7 @@ function S3Stream(params, s3) {
   Writable.call(this)
 
   // Cache inputs
-  this.params = params
+  this.params = params || {}
   this.s3 = s3
 
   // Set the stream's initial state, create a queue, and bind event listeners

--- a/lib/Stream.js
+++ b/lib/Stream.js
@@ -8,7 +8,8 @@ var S3Queue = require('./Queue')
  * Writable stream interface for S3. Inherits stream.Writable
  *
  * @constructor
- * @param {Object} params Same params object as AWS.S3.createMultipartUpload
+ * @param {Object|Null} params Same params object as AWS.S3.createMultipartUpload. Can be null if
+ *   all required params are set as defaults on the s3 param.
  * @param {String} params.Bucket The S3 bucket your file will go in.
  * @param {String} params.Key The full path to the object on S3, within its bucket.
  * @param {Object} s3 Authenticated instance of AWS.S3

--- a/test/awsShim.js
+++ b/test/awsShim.js
@@ -78,6 +78,12 @@ describe('AWS Shim, testing the tests', function () {
         done(err)
       })
     })
+
+    it('Should support default parameters', function (done) {
+      // No bucket is passed when the upload is created
+      var s3shim = new awsShim.S3({params: {Bucket: 'new-bucket'}})
+      s3shim.createMultipartUpload({Key: 'another-file'}, done)
+    })
   })
 
 

--- a/test/createWriteStream.js
+++ b/test/createWriteStream.js
@@ -39,6 +39,16 @@ describe('S3 createWriteStream', function () {
     immediateStream.should.be.instanceof(require('stream').Writable)
   })
 
+  it('Should support optional parameters', function (done) {
+    var s3Shim = new awsShim.S3({params: {
+      Bucket: 'another-bucket',
+      Key: 'another-file'
+    }})
+    var canoe = new Canoe(s3Shim)
+
+    canoe.createWriteStream(done)
+  })
+
   it('Should be writable', function (done) {
     getStream(function (err, stream) {
       stream.write("And we will never be alone again").should.be.ok

--- a/test/createWriteStream.js
+++ b/test/createWriteStream.js
@@ -6,7 +6,7 @@ var should = require('should')
 
 // Replace the AWS library with the shim
 var awsShim = require('./shim/aws')
-var S3Utils = require('../index')
+var Canoe = require('../index')
 
 var getStream = function (threshold, cb) {
   if (typeof threshold === 'function') {
@@ -15,9 +15,9 @@ var getStream = function (threshold, cb) {
   }
 
   var s3Shim = new awsShim.S3()
-  var s3Utils = new S3Utils(s3Shim)
+  var canoe = new Canoe(s3Shim)
   var params = {Bucket: 'test-bucket', Key: 'testkey.log', Threshold: threshold}
-  return s3Utils.createWriteStream(params, cb)
+  return canoe.createWriteStream(params, cb)
 }
 
 var getLargeString = function (numMegs) {

--- a/test/shim/aws.js
+++ b/test/shim/aws.js
@@ -13,13 +13,25 @@ module.exports = AWS
 
 var NETWORK_TIMEOUT = 10
 
-AWS.S3 = function () {
+AWS.S3 = function (opts) {
+  opts = opts || {}
+
   // An easy way to confirm we're using the shim
   this.shim = true
+
+  this.defaultParams = opts.params || {}
 }
 
 AWS.S3.prototype.createMultipartUpload = function (params, callback) {
   var _this = this
+
+  // Merge default params
+  params = params || {}
+  for (var key in this.defaultParams) {
+    if (! this.defaultParams.hasOwnProperty(key)) continue;
+    params[key] = params[key] || this.defaultParams[key]
+  }
+
   setTimeout(function () {
     var required = ['Bucket', 'Key']
     for (var i = 0; i < required.length; i++) {


### PR DESCRIPTION
Hello @tylerneylon, 

This adds support for default parameters, which the AWS SDK supports. Specifically, the changes:
- Update the AWS shim to support default params
- Adds test using default params
- Adds support for not passing a params object if all of your params are already set as defaults

The newly supported use would look something like this.

``` javascript
var AWS = require('aws-sdk')
var Canoe = require('canoe')

// This sets up the s3 object with all of the params we need
var s3 = new AWS.S3({params: {
  Bucket: 'bucket-name',
  Key: 'file.txt'
}})

function canoeStreamCallback(err, stream) {
  // If it turns out that you were missing requires params, you'll get an error here
  if (err) return console.error(err)

  stream.end('Hello world')
}

// Now we're not going to pass any params to canoe
canoe.createWriteStream(canoeStreamCallback)

// You can also override defaults for specific instances
canoe.createWriteStream({Key: 'another-file.txt'}, canoeStreamCallback)
```

Please review the following commits I made in branch 'es-handle-default-params'.

c3db2028b4a178ba274aa55a7a4ebbe590b20d5d (2013-12-10 18:15:22 -0800)
Make params argument to createWriteStream() optional
If all of your params have been setup as defaults then you may not need to pass any params. You'll get an error if any required params (Bucket and Key) are missing.

3f67db252efa26b6f7eec3c1aa6368cd68581cef (2013-12-10 18:05:57 -0800)
Update old name

d23b788f2eaa9ecb2ccad98f9151a14afed20c83 (2013-12-10 17:47:48 -0800)
Fallback to S3Stream params being an empty object
If the S3 object was created with default params, this could legitimately be null-ish

ce4df71a16480f322ffb2cb937bed653b56ec060 (2013-12-10 17:44:45 -0800)
Explicitly check that UploadId is defined

ca4adf3a2b691ac1399445762d1a3f489e33c6b9 (2013-12-10 17:22:34 -0800)
Support default params in shim S3 constructor

R=@tylerneylon
