### PR TITLE
Fix for "InvalidParameterType: Expected params.PartNumber to be a number"

### DIFF
--- a/lib/Stream.js
+++ b/lib/Stream.js
@@ -188,7 +188,7 @@ S3Stream.prototype.upload = function (body) {
 
   var params = this.getUploadParams({
     Body: body,
-    PartNumber: partNumber.toString()
+    PartNumber: partNumber
   })
 
   this.activeUploads++


### PR DESCRIPTION
They've added some more client side validation to aws-sdk recently which leads to this really fun type error...

```
InvalidParameterType: Expected params.PartNumber to be a number
    at fail (/Users/hrabovsk/sdgr/node-depy/node_modules/aws-sdk/lib/param_validator.js:125:26)
    at validateType (/Users/hrabovsk/sdgr/node-depy/node_modules/aws-sdk/lib/param_validator.js:152:10)
    at validateScalar (/Users/hrabovsk/sdgr/node-depy/node_modules/aws-sdk/lib/param_validator.js:111:21)
    at validateMember (/Users/hrabovsk/sdgr/node-depy/node_modules/aws-sdk/lib/param_validator.js:75:21)
    at validateStructure (/Users/hrabovsk/sdgr/node-depy/node_modules/aws-sdk/lib/param_validator.js:55:14)
    at validate (/Users/hrabovsk/sdgr/node-depy/node_modules/aws-sdk/lib/param_validator.js:30:17)
    at Request.VALIDATE_PARAMETERS (/Users/hrabovsk/sdgr/node-depy/node_modules/aws-sdk/lib/event_listeners.js:111:32)
    at Request.callListeners (/Users/hrabovsk/sdgr/node-depy/node_modules/aws-sdk/lib/sequential_executor.js:132:20)
    at Request.<anonymous> (/Users/hrabovsk/sdgr/node-depy/node_modules/aws-sdk/lib/sequential_executor.js:123:18)
    at /Users/hrabovsk/sdgr/node-depy/node_modules/aws-sdk/lib/event_listeners.js:98:9
```

Just need to not call toString().
