### PR TITLE
Handle inconsistent type validation in s3.uploadPart()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.3.1
+#### January 3, 2014
+* `S3Stream` -- Handle inconsistent type checking for `PartNumber` param in the AWS SDK. Allows Canoe to work with AWS versions that would previously have thrown errors on every upload (1.15.0 - 1.17.0 and 2.0.0-rc1 - 2.0.0-rc5).
+
 ### 0.3.0
 #### November 21, 2013
 * `S3Stream` -- Fix a race condition that caused the upload to be completed to early when `end()` happened to get called while there were no active uploads.

--- a/lib/Stream.js
+++ b/lib/Stream.js
@@ -35,7 +35,7 @@ S3Stream.prototype.init = function () {
   this.uploadPartNumber = 0
   this.uploadedParts = []
   this.activeUploads = 0
-  this.maxActiveUploads = 1
+  this.stringifyPartNumber = false
 
   // Setup a queue instance
   this.setupQueue()
@@ -132,7 +132,7 @@ S3Stream.prototype._write = function (chunk, encoding, callback) {
  * @return {Boolean} True if the stream is ready.
  */
 S3Stream.prototype.ready = function () {
-  return !! (this.initialized() && this.activeUploads < this.maxActiveUploads)
+  return !! (this.initialized() && this.activeUploads === 0)
 }
 
 /**
@@ -173,6 +173,10 @@ S3Stream.prototype.getUploadParams = function (extraParams) {
     params[key] = extraParams[key]
   })
 
+  if (this.stringifyPartNumber && params.PartNumber) {
+    params.PartNumber = params.PartNumber.toString()
+  }
+
   return params
 }
 
@@ -188,14 +192,28 @@ S3Stream.prototype.upload = function (body) {
 
   var params = this.getUploadParams({
     Body: body,
-    PartNumber: partNumber.toString()
+    PartNumber: partNumber
   })
 
   this.activeUploads++
   this.s3.uploadPart(params, function (err, response) {
     _this.activeUploads--
 
-    if (err) {
+    // Handle cases where we get an invalid type but might still be able to duck punch our
+    // way into a valid type. This allows Canoe to work with any version of the AWS SDK, even
+    // though we have no way to actually know what version we're using.
+    //
+    // If we get an InvalidParameterType error, we'll set a flag to cast PartNumber params
+    // as strings and try again. We'll also decrement the upload part number because S3 never
+    // got that part.
+    //
+    // See: https://github.com/Obvious/canoe/pull/22
+    var retryAsString = err && err.name === 'InvalidParameterType' && ! _this.stringifyPartNumber
+    if (retryAsString) {
+      _this.uploadPartNumber--
+      _this.stringifyPartNumber = true
+      return _this.upload(body)
+    } else if (err) {
       _this.emit('error', err)
     } else {
       // Maintain `ETag` and `PartNumber` data about each uploaded part
@@ -205,8 +223,8 @@ S3Stream.prototype.upload = function (body) {
         PartNumber: partNumber
       })
     }
-    _this.emit('uploaded', err, response, body)
 
+    _this.emit('uploaded', err, response, body)
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canoe",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "engines": {
     "node": ">=0.10.0"
   },

--- a/test/shim/aws.js
+++ b/test/shim/aws.js
@@ -16,6 +16,9 @@ var NETWORK_TIMEOUT = 10
 AWS.S3 = function () {
   // An easy way to confirm we're using the shim
   this.shim = true
+
+  // https://github.com/Obvious/canoe/pull/22
+  this.requireUploadPartType = null
 }
 
 AWS.S3.prototype.createMultipartUpload = function (params, callback) {
@@ -58,8 +61,11 @@ AWS.S3.prototype.uploadPart = function (params, callback) {
         return callback(new Error(required[i] + ' is required'))
     }
 
-    if (typeof params.PartNumber !== 'string') {
-      return callback(new Error('PartNumber must be a String'))
+    // The PartNumber param is type agnostic. It used to be strict, but inconsistent.
+    //
+    // https://github.com/Obvious/canoe/pull/22
+    if (_this.requireUploadPartType && typeof params.PartNumber !== _this.requireUploadPartType) {
+      return callback(new Error('PartNumber must be a ' + _this.requireUploadPartType))
     }
 
     if (params.UploadId !== _this.cachedUploadId) {


### PR DESCRIPTION
Hello @evansolomon, 

Please review the following commits I made in branch 'bugfix/22'.

61298f3db480df3ce2f1779fd04f316ed5fa6e01 (2014-01-03 12:22:41 -0800)
Handle inconsistent type validation in s3.uploadPart()
The AWS SDK has had different type validation for the PartNumber
param in different versions. Since Canoe doesn't have a reference to
the root AWS object it has no way to tell what version is being used.

To handle the different behavior we can check the errors the SDK
responds with and sometimes guess our way into a successful second
attempt. If the second attempt fails, then we'll give up and bubble
the error up as usual.

Because this introduces a case where we may attempt the "same" upload
multiple times, there's a chance it introduces a race condition when
multiple concurrent uploads are allowed. To be safe, I'm removing the
ability to upload more than one part at a time. I'll revert that
change if/when I'm sure that there's no race condition.

Fixes #22

R=@evansolomon
