### PR TITLE
Add createPrefixedReadStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,26 @@ var canoe = new Canoe(s3);
 
 ## Methods
 
+### createPrefixedReadStream
+
+Create a readable stream of all objects whose keys match a given prefix.
+
+#### Usage
+
+Combines multiple objects into a single readable stream, preserving the order of the objects.
+
+```javascript
+// This will stream all objects starting with "path/to/things/name_"
+// For example, it would match "path/to/things/name_1", "path/to/things/name_2", etc
+canoe.createPrefixedReadStream({
+  Bucket: 'bucket-name',
+  Prefix: 'path/to/things/name_'
+}, function (err, readable) {
+  readable.pipe(process.stdout)
+})
+```
+
+
 ### createWriteStream
 
 A Node 0.10-friendly writable stream interface ("streams2") for uploading objects to S3.

--- a/lib/CombinedReadable.js
+++ b/lib/CombinedReadable.js
@@ -1,0 +1,50 @@
+// Copyright 2014 A Medium Corporation.
+
+var util = require('util')
+var Readable = require('stream').Readable
+
+/**
+ * Combines an array of readable streams and exposes them as a single
+ * readable stream. Order is preserved.
+ *
+ * @constructor
+ * @param {Array.<stream.Readable>} sources Readable streams to combine
+ * @param {Object=} opts Stream options
+ */
+function CombinedReadable(sources, opts) {
+  Readable.call(this, opts)
+
+  this._sources = sources
+  this._sources.forEach(function (stream) {
+    stream.on('error', this.emit.bind(this, 'error'))
+    stream.on('end', this._nextSource.bind(this))
+  }.bind(this))
+
+  this._nextSource()
+}
+util.inherits(CombinedReadable, Readable)
+module.exports = CombinedReadable
+
+/**
+ * Begin sending data to consumers
+ */
+CombinedReadable.prototype._read = function () {
+  this._currentSource.resume()
+}
+
+/**
+ * Use the next source and pass its data to the consumer. If all
+ * sources are ended, finish the stream.
+ */
+CombinedReadable.prototype._nextSource = function () {
+  this._currentSource = this._sources.shift()
+  if (! this._currentSource) {
+    return this.push(null)
+  }
+
+  this._currentSource.on('data', function (chunk) {
+    if (! this.push(chunk)) {
+      this._currentSource.pause()
+    }
+  }.bind(this))
+}

--- a/test/CombinedReadable.js
+++ b/test/CombinedReadable.js
@@ -1,0 +1,43 @@
+// Copyright 2014 A Medium Corporation.
+
+var fs = require('fs')
+var path = require('path')
+var Readable = require('stream').Readable
+var should = require('should')
+var CombinedReadable = require('../lib/CombinedReadable')
+
+var filePaths = {
+  one: path.join(__dirname, './files/one'),
+  two: path.join(__dirname, './files/two')
+}
+
+describe('Combined Readable', function () {
+  it('Should exist', function () {
+    should.exist(CombinedReadable)
+  })
+
+  it('Should create a stream', function () {
+    var files = [fs.createReadStream(filePaths.one), fs.createReadStream(filePaths.two)]
+    var combined = new CombinedReadable(files)
+    combined.should.be.instanceof(Readable)
+  })
+
+  it('Should combine the output', function (done) {
+    var files = [filePaths.one, filePaths.two]
+    var data = files.map(function (file) {
+      return fs.readFileSync(file, 'utf8')
+    }).join('')
+
+    var combined = new CombinedReadable(files.map(fs.createReadStream))
+    var out = ''
+    combined.on('data', function (chunk) {
+      out += chunk
+    })
+
+    combined.on('error', done)
+    combined.on('end', function () {
+      out.should.eql(data)
+      done()
+    })
+  })
+})

--- a/test/files/one
+++ b/test/files/one
@@ -1,0 +1,2 @@
+Hello
+World

--- a/test/files/two
+++ b/test/files/two
@@ -1,0 +1,2 @@
+Evan
+Pete


### PR DESCRIPTION
Hello @x-ma, 

Please review the following commits I made in branch 'es-prefixed-read'.

4a20a64971249a81b22fe2004d3a02590075c684 (2014-02-18 17:37:13 -0800)
Add createPrefixedReadStream
Downloads all S3 objects that match a prefix as a single stream. Useful for tools that create multiple S3 files for a single data source like Redshift's UNLOAD command.

R=@x-ma
